### PR TITLE
:changed origin/master HEAD

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :eval-in-leiningen true
   :aliases {"all" ["do" "clean," "test," "install"]}
   :signing {:gpg-key "92439EF5"}
+  :dependencies [[me.arrdem/cuddlefish "0.1.0"]]
   :plugins [[lein-file-replace "0.1.0"]]
   :deploy-repositories {"releases" :clojars}
   :release-tasks

--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -105,7 +105,12 @@
   directories (Files) to a sets of project symbols. This enables us to
   localize file changes to impacted projects."
   [pm]
-  nil)
+  (reduce (fn [acc [sym proj]]
+            (reduce (fn [acc root]
+                      (update acc root (fnil conj #{}) root))
+                    acc (cons (:root proj)
+                              (mapcat proj [:source-paths :resource-paths]))))
+          {} pm))
 
 (defn impacted
   "Transforms a \"roots\" map of Files to sets of project symbols and a


### PR DESCRIPTION
One really nice feature that [pantsbuild](https://www.pantsbuild.org/) and other monorepo build tools have is the ability to do efficient target invalidation - that is to introspect version control history and decide eg `./pants changed --changed-parent=origin/develop --changed-include-dependees=transitive` which will print the names of all changed targets. This, together with selective test running machinery enables test suites to scale to immense size while remaining tractable because only the tests "invalidated" (depending directly or transitively on changed code) need to be run.

This changeset brings in my [cuddlefish](https://github.com/arrdem/cuddlefish) library to interface with git, and equips `lein-modules` with a `:changed <base> <head>` selector for running tasks against changed targets.

At present this selector always requires both base and head refs. It also always includes transitively impacted targets in the new build.

Comment welcome on the precise form of the `:changed` directive.